### PR TITLE
  fix: Order result of record name by name matching

### DIFF
--- a/src/route53.ts
+++ b/src/route53.ts
@@ -63,10 +63,10 @@ export const needsUpdateRecord = async (
 ) => {
   logger.info(`[route53] 🔍 Looking for a matching record...`);
 
-  // todo: handle many records
   const { ResourceRecordSets } = await route53
     .listResourceRecordSets({
       HostedZoneId: hostedZoneId,
+      StartRecordName: domainName,
     })
     .promise();
 


### PR DESCRIPTION
There is a max number of records returned from this aws command so specifying a name ensure we have the record we're looking for in the list